### PR TITLE
chore: add env example and verification script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# ---------- SQL ----------
+SQL_SERVER=<server>.database.windows.net
+SQL_DB=Beacon-FinanceMart
+SQL_USER=<user>
+SQL_PASSWORD=<password>
+SQL_ENCRYPT=true
+
+# ---------- QUICKBOOKS ONLINE ----------
+QBO_CLIENT_ID=
+QBO_CLIENT_SECRET=
+QBO_REDIRECT_URI=
+QBO_REALM_ID=
+QBO_REFRESH_TOKEN=
+
+# ---------- HUBSPOT ----------
+HUBSPOT_PRIVATE_APP_TOKEN=
+
+# ---------- CONNECTEAM ----------
+CONNECTEAM_API_TOKEN=
+
+# ---------- AZURE SERVICE BUS ----------
+SB_CONNECTION_STRING=
+SB_QUEUE_VENDOR_UPSERT=vendor-upsert
+SB_QUEUE_PROJECT_CREATE=project-create
+
+# ---------- AUTH / ENTRA ID ----------
+ENTRA_TENANT_ID=
+ENTRA_CLIENT_ID=
+ENTRA_CLIENT_SECRET=
+ALLOWED_EMAIL_DOMAIN=beaconfirepro.com
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Monorepo for the Lighthouse platform.
 
+## Environment setup
+1. Copy `.env.example` to `.env` and fill in values as available.
+2. Do not commit `.env`. Secrets live in local `.env` for dev and in Key Vault for cloud.
+3. Minimal must-haves to run later tasks:
+   - SQL_SERVER, SQL_DB, SQL_USER, SQL_PASSWORD
+   - SB_CONNECTION_STRING
+   - QBO*, HUBSPOT*, CONNECTEAM* can remain blank for now
+
 ## Structure
 - apps/web  Next.js admin app
 - apps/api  Express REST API
@@ -16,3 +24,4 @@ Monorepo for the Lighthouse platform.
 - npm run build  build all
 - npm run lint  lint all
 - npm run test  test all
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "format": "prettier -w .",
-    "verify:bootstrap": "node scripts/verify_task1.mjs"
+    "verify:bootstrap": "node scripts/verify_task1.mjs",
+    "verify:env": "node scripts/verify_env.mjs"
   },
   "devDependencies": {
     "eslint": "^9.9.0",
@@ -26,3 +27,4 @@
     "typescript": "^5.5.4"
   }
 }
+

--- a/scripts/verify_env.mjs
+++ b/scripts/verify_env.mjs
@@ -1,0 +1,32 @@
+import { readFileSync, existsSync } from "node:fs";
+
+const path = ".env.example";
+if (!existsSync(path)) {
+  console.error("Missing .env.example");
+  process.exit(1);
+}
+
+const text = readFileSync(path, "utf8");
+const required = [
+  "SQL_SERVER",
+  "SQL_DB",
+  "SQL_USER",
+  "SQL_PASSWORD",
+  "SQL_ENCRYPT",
+  "SB_CONNECTION_STRING",
+  "SB_QUEUE_VENDOR_UPSERT",
+  "SB_QUEUE_PROJECT_CREATE",
+  "ENTRA_TENANT_ID",
+  "ENTRA_CLIENT_ID",
+  "ENTRA_CLIENT_SECRET",
+  "ALLOWED_EMAIL_DOMAIN"
+];
+
+const missing = required.filter(k => !new RegExp(`^${k}=`, "m").test(text));
+if (missing.length) {
+  console.error("Missing keys in .env.example:", missing);
+  process.exit(1);
+}
+
+console.log(".env.example verification passed ✅");
+


### PR DESCRIPTION
## Summary
- document environment setup and provide `.env.example`
- add script to verify required keys

## Testing
- `npm install`
- `npm run lint` *(fails: could not parse packageManager field)*
- `npm test` *(fails: could not parse packageManager field)*
- `npm run verify:env`

------
https://chatgpt.com/codex/tasks/task_e_68bcca0ac774832b8cb00f1d1a72aeae