### PR TITLE
chore(api): type health endpoint parameters

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import express from 'express';
+import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import pino from 'pino';
@@ -11,7 +11,7 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 
-app.get('/health', async (_req, res) => {
+app.get('/health', async (_req: Request, res: Response) => {
   try {
     const db = getDb();
     await db.raw('select 1 as ok');


### PR DESCRIPTION
## Summary
- import Request and Response from express
- type /health handler parameters for clarity

## Testing
- `npx prettier apps/api/src/index.ts -w`
- `npx eslint apps/api/src/index.ts` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1315a0c832b86e471f905470517