### PR TITLE
chore(api): type health route handler

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import express from 'express';
+import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import pino from 'pino';
@@ -11,7 +11,7 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 
-app.get('/health', async (_req, res) => {
+app.get('/health', async (_req: Request, res: Response) => {
   try {
     const db = getDb();
     await db.raw('select 1 as ok');


### PR DESCRIPTION
## Summary
- add Request and Response types to Express health check

## Testing
- `npx prettier apps/api/src/index.ts --write`
- `npm run lint` *(fails: could not resolve workspaces: We could not parse the packageManager field in package.json)*
- `npm test` *(fails: could not resolve workspaces: We could not parse the packageManager field in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1310490832b9578662096ad90e9