### PR TITLE
feat(web): add AP Run and Collections pages

### DIFF
--- a/apps/web/app/ap-run/page.tsx
+++ b/apps/web/app/ap-run/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Row = {
+  bill_id: number;
+  vendor_name: string;
+  open_balance: number;
+  due_date?: string;
+  pay_decision: string;
+};
+
+export default function APRun() {
+  const [rows, setRows] = useState<Row[]>([]);
+  useEffect(() => {
+    fetch('/ap/run')
+      .then((r) => r.json())
+      .then(setRows);
+  }, []);
+  return (
+    <main className="max-w-6xl mx-auto p-6">
+      <h1 className="text-xl font-semibold mb-4">AP Run</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th>Bill</th>
+            <th>Vendor</th>
+            <th>Due</th>
+            <th>Open</th>
+            <th>Decision</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.bill_id} className="border-t">
+              <td className="py-2">{r.bill_id}</td>
+              <td>{r.vendor_name}</td>
+              <td className="text-center">{r.due_date || '-'}</td>
+              <td className="text-right">{r.open_balance?.toFixed?.(2)}</td>
+              <td className="text-center">{r.pay_decision}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/apps/web/app/collections/page.tsx
+++ b/apps/web/app/collections/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Row = {
+  invoice_id: number;
+  client_name: string;
+  open_balance: number;
+  due_date?: string;
+  expected_receipt_date?: string;
+};
+
+export default function Collections() {
+  const [rows, setRows] = useState<Row[]>([]);
+  useEffect(() => {
+    fetch('/collections/run')
+      .then((r) => r.json())
+      .then(setRows);
+  }, []);
+  return (
+    <main className="max-w-6xl mx-auto p-6">
+      <h1 className="text-xl font-semibold mb-4">Collections</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th>Invoice</th>
+            <th>Client</th>
+            <th>Due</th>
+            <th>Open</th>
+            <th>Expected</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.invoice_id} className="border-t">
+              <td className="py-2">{r.invoice_id}</td>
+              <td>{r.client_name}</td>
+              <td className="text-center">{r.due_date || '-'}</td>
+              <td className="text-right">{r.open_balance?.toFixed?.(2)}</td>
+              <td className="text-center">{r.expected_receipt_date || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add AP Run page fetching `/ap/run` and listing bills
- add Collections page fetching `/collections/run` and listing invoices

## Testing
- `npm run lint` *(fails: could not parse packageManager field in package.json)*
- `npm test` *(fails: could not parse packageManager field in package.json)*
- `npm run build` *(fails: could not parse packageManager field in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdde924808832b9cb2e11422994383