### PR TITLE
feat: add project list and detail pages

### DIFF
--- a/apps/api/src/projects.ts
+++ b/apps/api/src/projects.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { getDb } from './db';
+
+const r = Router();
+
+r.get('/list/all', async (_req, res) => {
+  const db = getDb();
+  const rows = await db('dim_project')
+    .select('project_id', 'project_name', 'status')
+    .orderBy('project_id', 'desc')
+    .limit(200);
+  res.json(rows);
+});
+
+export default r;

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ProjectDetail({ params }: any) {
+  const id = Number(params.id);
+  const [data, setData] = useState<any>(null);
+  useEffect(() => {
+    fetch(`/projects/${id}/overview`)
+      .then((r) => r.json())
+      .then(setData);
+  }, [id]);
+  if (!data) return <div className="p-6">Loading…</div>;
+  return (
+    <main className="max-w-5xl mx-auto p-6">
+      <h1 className="text-xl font-semibold mb-4">Project #{id}</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left">Phase</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(data.phases || []).map((p: any) => (
+            <tr key={p.phase_id} className="border-t">
+              <td className="py-2">{p.phase_name}</td>
+              <td className="text-center">{p.status || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/apps/web/app/projects/page.tsx
+++ b/apps/web/app/projects/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Row = { project_id: number; project_name: string; status?: string };
+
+export default function Projects() {
+  const [rows, setRows] = useState<Row[]>([]);
+  useEffect(() => {
+    fetch('/projects/list/all')
+      .then((r) => r.json())
+      .then(setRows)
+      .catch(() => setRows([]));
+  }, []);
+  return (
+    <main className="max-w-5xl mx-auto p-6">
+      <h1 className="text-xl font-semibold mb-4">Projects</h1>
+      <ul className="space-y-2">
+        {rows.map((r) => (
+          <li key={r.project_id}>{r.project_name}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add projects listing page with API fetch
- add project detail page with phase table
- add API endpoint for project listing

## Testing
- `npm test` *(fails: could not resolve workspaces due to packageManager field)*
- `npm run lint` *(fails: could not resolve workspaces due to packageManager field)*
- `npm run dev` *(fails: could not resolve workspaces due to packageManager field)*

------
https://chatgpt.com/codex/tasks/task_e_68bdde803e38832b83344edd8ca9641a