### PR TITLE
chore: support node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "npm@11.4.2",
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=20 <21 || >=22 <23"
   },
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- allow Node.js 22 in package.json engines

## Testing
- `nvm install 20`
- `nvm use 20`
- `npm test`
- `nvm install 22`
- `nvm use 22`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be28a48554832bb2a04e7ec006be01