### PR TITLE
refactor: use db alias for API imports

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import pino from 'pino';
-import { getDb, closeDb } from '@shared/../db/src/knex.js';
+import { getDb, closeDb } from '@db/knex.js';
 
 // Routers
 import ahj from './ahj.js';

--- a/apps/api/src/projects.ts
+++ b/apps/api/src/projects.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { getDb } from './db';
+import { getDb } from '@db/knex.js';
 
 const r = Router();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,10 @@
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
-    "paths": { "@shared/*": ["packages/shared/*"] }
+    "paths": {
+      "@shared/*": ["packages/shared/*"],
+      "@db": ["packages/db/src"],
+      "@db/*": ["packages/db/src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add `@db` alias to root tsconfig
- use `@db` alias in API imports

## Testing
- `npm test` *(fails: Unable to parse packages/db/package.json)*
- `npm run lint` *(fails: Unable to parse packages/db/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be4e8291b4832b9a1144a8fa9e3391