### PR TITLE
feat(api): add project overview endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,16 +1,3 @@
-import express from 'express';
-import ahj from './ahj.js';
-
-const app = express();
-app.use(express.json());
-app.use('/ahj', ahj);
-
-const port = process.env.PORT ?? 3000;
-app.listen(port, () => {
-  console.log(`API listening on port ${port}`);
-});
-
-export default app;
 import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import helmet from 'helmet';
@@ -20,6 +7,7 @@ import { getDb, closeDb } from '@db/knex.js';
 
 // Routers
 import ahj from './ahj.js';
+import projects from './projects.js';
 
 const app = express();
 const log = pino({ name: 'api' });
@@ -42,6 +30,7 @@ app.get('/health', async (_req: Request, res: Response) => {
 
 // Feature routes
 app.use('/ahj', ahj);
+app.use('/projects', projects);
 
 // Server
 const PORT = Number(process.env.API_PORT || 4000);

--- a/apps/api/src/projects.ts
+++ b/apps/api/src/projects.ts
@@ -1,9 +1,9 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
 import { getDb } from '@db/knex.js';
 
-const r = Router();
+const projects = Router();
 
-r.get('/list/all', async (_req, res) => {
+projects.get('/list/all', async (_req: Request, res: Response) => {
   const db = getDb();
   const rows = await db('dim_project')
     .select('project_id', 'project_name', 'status')
@@ -12,4 +12,23 @@ r.get('/list/all', async (_req, res) => {
   res.json(rows);
 });
 
-export default r;
+interface PhaseRow {
+  phase_id: number;
+  phase_name: string;
+  status: string | null;
+}
+
+projects.get('/:id/overview', async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const db = getDb();
+  const phases = await db('fact_project_phase as f')
+    .join('dim_phase as p', 'p.phase_id', 'f.phase_id')
+    .select<
+      PhaseRow[]
+    >(['p.phase_id as phase_id', 'p.phase_name as phase_name', 'f.status as status'])
+    .where('f.project_id', id)
+    .orderBy('p.phase_id', 'asc');
+  res.json({ phases });
+});
+
+export default projects;


### PR DESCRIPTION
## Summary
- add projects router to API index
- implement `GET /:id/overview` to return project phases

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee775a990832bbb6ebce5ed057bba