### PR TITLE
refactor: centralize worker job completion

### DIFF
--- a/apps/worker/src/vendor-upsert/index.ts
+++ b/apps/worker/src/vendor-upsert/index.ts
@@ -1,6 +1,7 @@
 import { AzureFunction, Context } from '@azure/functions';
 import pino from 'pino';
-import { getDb, closeDb } from '@shared/../db/src/knex.js';
+import { getDb, closeDb } from '@db/knex.js';
+import { markJobDone } from '@shared/src/workerUtils.js';
 
 const log = pino({ name: 'vendor-upsert' });
 
@@ -11,11 +12,7 @@ const serviceBusTrigger: AzureFunction = async function (
   log.info({ message }, 'received');
   const db = getDb();
   try {
-    const jobId = message?.job_id || null;
-    await db('outbox_job')
-      .where({ job_id: jobId })
-      .update({ status: 'done', updated_at: db.fn.now() });
-    log.info({ jobId }, 'marked done');
+    await markJobDone(db, log, message);
   } catch (e) {
     log.error(e);
   } finally {

--- a/packages/shared/src/workerUtils.ts
+++ b/packages/shared/src/workerUtils.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+import type { Logger } from 'pino';
+
+export async function markJobDone(
+  db: Knex,
+  log: Logger,
+  message: any,
+): Promise<void> {
+  const jobId = message?.job_id || null;
+  await db('outbox_job')
+    .where({ job_id: jobId })
+    .update({ status: 'done', updated_at: db.fn.now() });
+  log.info({ jobId }, 'marked done');
+}


### PR DESCRIPTION
## Summary
- refactor worker handlers to use @db/knex.js
- extract shared markJobDone helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee777ef50832b91e90a4c771011af