### PR TITLE
feat: add shared response types and error handling

### DIFF
--- a/apps/web/app/ahj/page.tsx
+++ b/apps/web/app/ahj/page.tsx
@@ -1,28 +1,51 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
+import type { AHJ } from '@shared';
 
 export default function AHJ() {
-  const [rows, setRows] = useState<any[]>([]);
+  const [rows, setRows] = useState<AHJ[]>([]);
   const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
-    fetch('/ahj')
-      .then((r) => r.json())
-      .then(setRows);
+    async function load() {
+      try {
+        const res = await fetch('/ahj');
+        if (!res.ok) throw new Error('Failed to fetch AHJs');
+        const data: AHJ[] = await res.json();
+        setRows(data);
+      } catch (err) {
+        setError('Failed to load AHJs');
+        console.error(err);
+      }
+    }
+    load();
   }, []);
-  async function create(e: any) {
+
+  async function create(e: FormEvent) {
     e.preventDefault();
-    await fetch('/ahj', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    setName('');
-    const r = await fetch('/ahj');
-    setRows(await r.json());
+    try {
+      const res = await fetch('/ahj', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) throw new Error('Failed to create AHJ');
+      setName('');
+      const r = await fetch('/ahj');
+      if (!r.ok) throw new Error('Failed to fetch AHJs');
+      const data: AHJ[] = await r.json();
+      setRows(data);
+    } catch (err) {
+      setError('Failed to save AHJ');
+      console.error(err);
+    }
   }
+
   return (
     <main className="max-w-5xl mx-auto p-6 space-y-6">
       <h1 className="text-xl font-semibold">AHJ Directory</h1>
+      {error && <p className="text-red-600">{error}</p>}
       <form onSubmit={create} className="flex gap-2">
         <input
           className="border p-2 flex-1"

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -1,15 +1,34 @@
 'use client';
 import { useEffect, useState } from 'react';
+import type { ProjectDetail } from '@shared';
 
-export default function ProjectDetail({ params }: any) {
+interface PageProps {
+  params: { id: string };
+}
+
+export default function ProjectDetail({ params }: PageProps) {
   const id = Number(params.id);
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<ProjectDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
-    fetch(`/projects/${id}/overview`)
-      .then((r) => r.json())
-      .then(setData);
+    async function load() {
+      try {
+        const res = await fetch(`/projects/${id}/overview`);
+        if (!res.ok) throw new Error('Failed to fetch project');
+        const json: ProjectDetail = await res.json();
+        setData(json);
+      } catch (err) {
+        setError('Failed to load project');
+        console.error(err);
+      }
+    }
+    load();
   }, [id]);
+
+  if (error) return <div className="p-6">{error}</div>;
   if (!data) return <div className="p-6">Loading…</div>;
+
   return (
     <main className="max-w-5xl mx-auto p-6">
       <h1 className="text-xl font-semibold mb-4">Project #{id}</h1>
@@ -21,7 +40,7 @@ export default function ProjectDetail({ params }: any) {
           </tr>
         </thead>
         <tbody>
-          {(data.phases || []).map((p: any) => (
+          {(data.phases ?? []).map((p) => (
             <tr key={p.phase_id} className="border-t">
               <td className="py-2">{p.phase_name}</td>
               <td className="text-center">{p.status || '-'}</td>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,3 @@
+export * from './types';
+
 export const ok = true;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,23 @@
+export interface AHJ {
+  ahj_id: number;
+  name: string;
+  jurisdiction?: string | null;
+  code_sets_used?: string | null;
+  inspection_process_notes?: string | null;
+  portal_url?: string | null;
+  contact_list_json?: unknown | null;
+  inspection_lead_time_days?: number | null;
+  fee_schedule_url?: string | null;
+  email_pattern?: string | null;
+  active?: boolean | null;
+}
+
+export interface ProjectPhase {
+  phase_id: number;
+  phase_name: string;
+  status?: string | null;
+}
+
+export interface ProjectDetail {
+  phases?: ProjectPhase[] | null;
+}


### PR DESCRIPTION
## Summary
- add AHJ and ProjectDetail interfaces in shared package
- use typed responses in AHJ and project pages
- handle fetch errors in AHJ and project pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee779e3dc832bad02c06cbd0ea1e6