### PR TITLE
docs: document environment variables for migrations and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# ---------- API ----------
+API_PORT=4000
+
 # ---------- SQL ----------
 SQL_SERVER=<server>.database.windows.net
 SQL_DB=Beacon-FinanceMart

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monorepo for the Lighthouse platform.
 1. Copy `.env.example` to `.env` and fill in values as available.
 2. Do not commit `.env`. Secrets live in local `.env` for dev and in Key Vault for cloud.
 3. Minimal must-haves to run later tasks:
+   - API_PORT (default 4000)
    - SQL_SERVER, SQL_DB, SQL_USER, SQL_PASSWORD
    - SB_CONNECTION_STRING
    - QBO*, HUBSPOT*, CONNECTEAM* can remain blank for now

--- a/infra/sql/README.md
+++ b/infra/sql/README.md
@@ -1,0 +1,15 @@
+# SQL
+
+## Environment variables
+
+- `SQL_SERVER`
+- `SQL_DB`
+- `SQL_USER`
+- `SQL_PASSWORD`
+- `SQL_ENCRYPT` (default `true`)
+
+## Run Migrations and Seeds
+
+1. `export NODE_OPTIONS=--loader=ts-node/esm` – use ts-node’s ESM loader so the TypeScript `knexfile.ts` runs correctly.
+2. `npm run db:migrate`
+3. `npm run db:seed`


### PR DESCRIPTION
## Summary
- document API_PORT in env example and root README
- list SQL environment variables before migration steps
- note ts-node loader export before running database migrations

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in apps/worker and packages/shared)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6997b490832b9142fc10285c0730