### PR TITLE
refactor(shared): destructure job id in worker utils

### DIFF
--- a/packages/shared/src/workerUtils.ts
+++ b/packages/shared/src/workerUtils.ts
@@ -7,9 +7,7 @@ export async function markJobDone(
   message: unknown,
 ): Promise<void> {
 
-  const job = message as { job_id?: string | null };
-
-  const jobId = (message as { job_id?: string } | null)?.job_id ?? null;
+  const { job_id: jobId = null } = message as { job_id?: string | null };
 
   await db('outbox_job')
     .where({ job_id: jobId })


### PR DESCRIPTION
## Summary
- destructure `job_id` in `markJobDone` utility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf78d02b18832b938bce4b77e7be81