### PR TITLE
feat(api,web,shared): add vendor endpoints and shared type

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ await loadSecrets([
 // Routers
 import ahj from './ahj.js';
 import projects from './projects.js';
+import vendors from './vendors.js';
 
 const app = express();
 const log = pino({ name: 'api' });
@@ -53,6 +54,7 @@ app.get('/health', async (_req: Request, res: Response) => {
 // Feature routes
 app.use('/ahj', ahj);
 app.use('/projects', projects);
+app.use('/vendors', vendors);
 
 // Server
 const API_PORT = Number(process.env.API_PORT ?? 4000);

--- a/apps/api/src/vendors.ts
+++ b/apps/api/src/vendors.ts
@@ -1,0 +1,44 @@
+import { Router, Request, Response } from 'express';
+import { getDb } from '@db/knex.js';
+import type { Vendor } from '@shared/src/types.js';
+
+const vendors = Router();
+
+vendors.get('/', async (_req: Request, res: Response) => {
+  const db = getDb();
+  const rows = await db<Vendor>('dim_vendor')
+    .select('vendor_id', 'vendor_name', 'vendor_type', 'active')
+    .orderBy('vendor_name', 'asc')
+    .limit(500);
+  res.json(rows);
+});
+
+vendors.get('/:id', async (req: Request, res: Response) => {
+  const db = getDb();
+  const row = await db<Vendor>('dim_vendor')
+    .select('vendor_id', 'vendor_name', 'vendor_type', 'active')
+    .where({ vendor_id: Number(req.params.id) })
+    .first();
+  if (!row) return res.status(404).json({ error: 'not found' });
+  res.json(row);
+});
+
+vendors.put('/:id', async (req: Request, res: Response) => {
+  const db = getDb();
+  await db('dim_vendor')
+    .where({ vendor_id: Number(req.params.id) })
+    .update({
+      vendor_name: req.body?.vendorName,
+      vendor_type: req.body?.vendorType,
+      active: req.body?.active,
+      updated_at: db.fn.now(),
+    });
+  res.json({ ok: true });
+});
+
+vendors.post('/:id/push/qbo', async (_req: Request, res: Response) => {
+  // placeholder for QuickBooks integration
+  res.json({ queued: true });
+});
+
+export default vendors;

--- a/apps/web/app/vendors/[id]/page.tsx
+++ b/apps/web/app/vendors/[id]/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-
-interface Vendor {
-  vendor_name?: string;
-  vendor_type?: string;
-  active?: boolean;
-}
+import type { Vendor } from '@shared';
 
 export default function VendorDetail({ params }: { params: { id: string } }) {
   const id = Number(params.id);

--- a/apps/web/app/vendors/page.tsx
+++ b/apps/web/app/vendors/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { useEffect, useState } from 'react';
-type Row = { vendor_id: number; vendor_name: string; vendor_type: string; active: boolean };
+import type { Vendor } from '@shared';
+
 export default function Vendors() {
-  const [rows, setRows] = useState<Row[]>([]);
+  const [rows, setRows] = useState<Vendor[]>([]);
   useEffect(() => {
     fetch('/vendors')
       .then((r) => r.json())
-      .then(setRows);
+      .then((data: Vendor[]) => setRows(data));
   }, []);
   return (
     <main className="max-w-5xl mx-auto p-6">

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,3 +21,10 @@ export interface ProjectPhase {
 export interface ProjectDetail {
   phases?: ProjectPhase[] | null;
 }
+
+export interface Vendor {
+  vendor_id: number;
+  vendor_name: string;
+  vendor_type: string;
+  active: boolean;
+}

--- a/packages/shared/src/workerUtils.ts
+++ b/packages/shared/src/workerUtils.ts
@@ -6,9 +6,6 @@ export async function markJobDone(
   log: Logger,
   message: unknown,
 ): Promise<void> {
-
-  const job = message as { job_id?: string | null };
-
   const jobId = (message as { job_id?: string } | null)?.job_id ?? null;
 
   await db('outbox_job')


### PR DESCRIPTION
## Summary
- add REST endpoints for vendors with QuickBooks stub
- share Vendor type across API and web UI
- use shared typing in vendor pages

## Testing
- `npm run lint`
- `npm --prefix apps/api run build`
- `npm --prefix apps/web run build` *(fails: packageManager "yarn@npm@11.4.2" mismatch and type error in projects page)*

------
https://chatgpt.com/codex/tasks/task_e_68be61f38034832b93e9caed976182cd