### PR TITLE
fix: remove triple-slash route reference and explicit any types

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import express, { Request, Response } from 'express';
+import express, { type Request, type Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import pino from 'pino';
@@ -7,14 +7,7 @@ import appInsights from 'applicationinsights';
 import { getDb, closeDb } from '@db/knex.js';
 import { loadSecrets } from '@shared/src/keyVault.js';
 
-await loadSecrets([
-  'API_PORT',
-  'SQL_SERVER',
-  'SQL_DB',
-  'SQL_USER',
-  'SQL_PASSWORD',
-  'SQL_ENCRYPT',
-]);
+await loadSecrets(['API_PORT', 'SQL_SERVER', 'SQL_DB', 'SQL_USER', 'SQL_PASSWORD', 'SQL_ENCRYPT']);
 
 // Routers
 import ahj from './ahj.js';
@@ -24,14 +17,10 @@ import vendors from './vendors.js';
 const app = express();
 const log = pino({ name: 'api' });
 
-const aiConn = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+const aiConn: string | undefined = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
 if (aiConn) {
-  appInsights
-    .setup(aiConn)
-    .setAutoCollectConsole(true, true)
-    .start();
+  appInsights.setup(aiConn).setAutoCollectConsole(true, true).start();
 }
-
 
 // Middleware
 app.use(helmet());
@@ -47,7 +36,6 @@ app.get('/health', async (_req: Request, res: Response) => {
   } catch (e: unknown) {
     const err = e as Error;
     res.status(500).json({ status: 'error', error: err.message || 'db error' });
-
   }
 });
 
@@ -57,7 +45,7 @@ app.use('/projects', projects);
 app.use('/vendors', vendors);
 
 // Server
-const API_PORT = Number(process.env.API_PORT ?? 4000);
+const API_PORT: number = Number(process.env.API_PORT ?? 4000);
 app.listen(API_PORT, () => log.info(`API listening on :${API_PORT}`));
 
 // Graceful shutdown

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+import './.next/types/routes.d.ts';
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/worker/src/project-create/index.ts
+++ b/apps/worker/src/project-create/index.ts
@@ -17,7 +17,7 @@ const serviceBusTrigger: AzureFunction = async function (
   const db = getDb();
   try {
     await markJobDone(db, log, message);
-  } catch (e) {
+  } catch (e: unknown) {
     log.error(e);
   } finally {
     await closeDb();

--- a/apps/worker/src/vendor-upsert/index.ts
+++ b/apps/worker/src/vendor-upsert/index.ts
@@ -17,7 +17,7 @@ const serviceBusTrigger: AzureFunction = async function (
   const db = getDb();
   try {
     await markJobDone(db, log, message);
-  } catch (e) {
+  } catch (e: unknown) {
     log.error(e);
   } finally {
     await closeDb();

--- a/packages/shared/src/workerUtils.ts
+++ b/packages/shared/src/workerUtils.ts
@@ -1,13 +1,16 @@
 import type { Knex } from 'knex';
 import type { Logger } from 'pino';
 
+interface OutboxMessage {
+  job_id?: string;
+}
+
 export async function markJobDone(
   db: Knex,
   log: Logger,
-  message: unknown,
+  message: OutboxMessage | null,
 ): Promise<void> {
-
-  const jobId = (message as { job_id?: string } | null)?.job_id ?? null;
+  const jobId = message?.job_id ?? null;
 
   await db('outbox_job')
     .where({ job_id: jobId })


### PR DESCRIPTION
## Summary
- replace triple-slash route reference with an import in `next-env.d.ts`
- remove explicit `any` usages in API and worker utilities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf86dd666c832bb825208bd06d6358